### PR TITLE
New Article: AWS Finally Understood That Nobody Likes Surprise Bills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1549,6 +1549,11 @@
         <a href="https://builder.aws.com/content/32IBb29euv4sdtxYr4XcfC9ECFF/how-i-built-a-full-serverless-platform-in-72-hours-using-kiro-without-writing-code" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">How I Built a Full Serverless Platform in 72 Hours Using Kiro — Without Writing Code</a>
         <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">A TAM used Kiro to build a complete community platform with S3, CloudFront, Cognito, Lambda, and API Gateway — all through conversation with AI. Architecture, problems, and lessons learned.</p>
       </div>
+      <div style="background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:20px 24px;margin-bottom:12px;transition:all 0.3s;" onmouseover="this.style.borderColor='rgba(255,215,0,0.4)'" onmouseout="this.style.borderColor='var(--border)'">
+        <p style="color:var(--text-muted);font-size:0.7em;margin-bottom:4px;"><span style="background:rgba(255,215,0,0.15);color:var(--gold);padding:2px 8px;border-radius:4px;font-size:0.9em;font-weight:600;margin-right:6px;">📝 Article</span> May 01, 2026 · <span style="color:var(--gold);font-style:italic;">Ricardo Gulias</span></p>
+        <a href="https://builder.aws.com/content/3D6DxKr47HkYZkCY7d2efzYTu1B/aws-finally-understood-that-nobody-likes-surprise-bills" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">AWS Finally Understood That Nobody Likes Surprise Bills</a>
+        <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">AWS launched flat-rate pricing plans for CloudFront in November 2025 — fixed monthly prices starting at $0 that bundle CDN, WAF, DDoS protection, and DNS with zero overage charges. This article breaks down the math, the limitations, and who actually benefits from this shift.</p>
+      </div>
     </div>
   </section>
   <script>


### PR DESCRIPTION
## New Article Submission

**Title:** AWS Finally Understood That Nobody Likes Surprise Bills
**URL:** https://builder.aws.com/content/3D6DxKr47HkYZkCY7d2efzYTu1B/aws-finally-understood-that-nobody-likes-surprise-bills
**Summary:** AWS launched flat-rate pricing plans for CloudFront in November 2025 — fixed monthly prices starting at $0 that bundle CDN, WAF, DDoS protection, and DNS with zero overage charges. This article breaks down the math, the limitations, and who actually benefits from this shift.
**Author:** Ricardo Gulias (ricardo.gulias@darede.com.br)
**Date:** May 01, 2026

> Review and merge to publish on the site.