### PR TITLE
New Article: Hosting an MCP Server on AWS in 2026: Four Paths and How to Choose

### DIFF
--- a/index.html
+++ b/index.html
@@ -1626,6 +1626,11 @@
         <a href="https://builder.aws.com/content/3D6DxKr47HkYZkCY7d2efzYTu1B/no-more-surprise-bills-what-cloudfronts-flatrate-pricing-really-changes" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">No More Surprise Bills: What CloudFront’s Flat‑Rate Pricing Really Changes</a>
         <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">A technical breakdown of CloudFront’s flat‑rate pricing, explaining when it delivers massive savings, where its limits matter, and how it changes the risk model of running public‑facing workloads on AWS.</p>
       </div>
+      <div style="background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:20px 24px;margin-bottom:12px;transition:all 0.3s;" onmouseover="this.style.borderColor='rgba(255,215,0,0.4)'" onmouseout="this.style.borderColor='var(--border)'">
+        <p style="color:var(--text-muted);font-size:0.7em;margin-bottom:4px;"><span style="background:rgba(255,215,0,0.15);color:var(--gold);padding:2px 8px;border-radius:4px;font-size:0.9em;font-weight:600;margin-right:6px;">📝 Article</span> May 07, 2026 · <span style="color:var(--gold);font-style:italic;">Erick Mancz</span></p>
+        <a href="https://medium.com/aws-tip/hosting-an-mcp-server-on-aws-in-2026-four-paths-and-how-to-choose-f3510ae378b8" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">Hosting an MCP Server on AWS in 2026: Four Paths and How to Choose</a>
+        <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">The 2026 guide to host an MCP Server on AWS</p>
+      </div>
     </div>
   </section>
   <script>


### PR DESCRIPTION
## New Article Submission

**Title:** Hosting an MCP Server on AWS in 2026: Four Paths and How to Choose
**URL:** https://medium.com/aws-tip/hosting-an-mcp-server-on-aws-in-2026-four-paths-and-how-to-choose-f3510ae378b8
**Summary:** The 2026 guide to host an MCP Server on AWS
**Author:** Erick Mancz (erickmancz@gmail.com)
**Date:** May 07, 2026

> Review and merge to publish on the site.