### PR TITLE
📝 New article: 5 MCP Tools That Replaced My AWS Console

### DIFF
--- a/index.html
+++ b/index.html
@@ -1958,6 +1958,11 @@
         <a href="https://builder.aws.com/content/3EYjQfXbXkdsutYhVZdqGYwhE81/from-1-country-to-9-in-60-days-scaling-a-global-aws-community-with-ai-and-serverless" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">From 1 Country to 9 in 60 Days — Scaling a Global AWS Community with AI and Serverless</a>
         <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">How a TAM used Amazon Bedrock, Kiro, and serverless to scale Golden Jackets from 14 to 89 members across 9 countries in 60 days.</p>
       </div>
+        <div style="background:var(--bg2);border:1px solid var(--border);border-radius:12px;padding:20px 24px;margin-bottom:12px;transition:all 0.3s;" onmouseover="this.style.borderColor='rgba(255,215,0,0.4)'" onmouseout="this.style.borderColor='var(--border)'">
+        <p style="color:var(--text-muted);font-size:0.7em;margin-bottom:4px;"><span style="background:rgba(255,215,0,0.15);color:var(--gold);padding:2px 8px;border-radius:4px;font-size:0.9em;font-weight:600;margin-right:6px;">📝 Article</span> Jun 08, 2026 · <span style="color:var(--gold);font-style:italic;">Ricardo Gulias</span></p>
+        <a href="https://builder.aws.com/content/3Er5I8UnnCmmNDDLLF25oRVJ38K/5-mcp-tools-that-replaced-my-aws-console-how-i-operate-multi-account-from-the-terminal" target="_blank" rel="noopener noreferrer" style="color:var(--gold);font-weight:700;font-size:1em;text-decoration:none;">5 MCP Tools That Replaced My AWS Console</a>
+        <p style="color:var(--text-muted);font-size:0.85em;margin-top:6px;">How I built 5 lightweight MCP tools to manage multi-account AWS from the terminal — no console, 45 min/day saved</p>
+      </div>
         <!-- END_ARTICLES -->
     </div>
   </section>


### PR DESCRIPTION
**Title:** 5 MCP Tools That Replaced My AWS Console
**URL:** https://builder.aws.com/content/3Er5I8UnnCmmNDDLLF25oRVJ38K/5-mcp-tools-that-replaced-my-aws-console-how-i-operate-multi-account-from-the-terminal
**Summary:** How I built 5 lightweight MCP tools to manage multi-account AWS from the terminal — no console, 45 min/day saved
**Author:** ricardo.gulias@goldenjacketsbrazil.com

_Auto-generated by article submission form._